### PR TITLE
Pull base image by arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,33 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
-  docker:
+  compile:
     needs: [test]
     if: github.repository == 'tensorchord/Horust'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - uses: taiki-e/install-action@cross
+      - name: Install cross-compilation tools
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - run: cross build --target ${{ matrix.target }} --release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/horust
+
+  docker:
+    needs: [compile]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -33,23 +57,24 @@ jobs:
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_TOKEN }}
-      - name: Docker Setup QEMU
-        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: build amd64 image
+      - run: mkdir arm64 && mkdir amd64
+      - name: Download linux/arm64 artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: aarch64-unknown-linux-gnu
+          path: arm64
+      - name: Download linux/amd64 artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: x86_64-unknown-linux-gnu
+          path: amd64
+      - run: chmod 777 arm64/horust &&  chmod 777 amd64/horust
+      - name: build multi-arch 
         run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          docker buildx build \
+            VERSION=$(git describe --tags --abbrev=0)
+            docker buildx build \
             -t tensorchord/horust:${VERSION} -f envd.Dockerfile \
-            --platform linux/amd64 \
-            --build-arg ARCH=x86_64 \
-            --pull --push .
-      - name: build arm64 image
-        run: |
-          VERSION=$(git describe --tags --abbrev=0)
-          docker buildx build \
-            -t tensorchord/horust:${VERSION} -f envd.Dockerfile \
-            --platform linux/arm64 \
-            --build-arg ARCH=aarch64 \
+            --platform linux/amd64,linux/arm64 \
             --pull --push .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,19 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: build image
+      - name: build amd64 image
         run: |
           VERSION=$(git describe --tags --abbrev=0)
           docker buildx build \
             -t tensorchord/horust:${VERSION} -f envd.Dockerfile \
-            --platform linux/amd64,linux/arm64 \
+            --platform linux/amd64 \
+            --build-arg ARCH=x86_64 \
+            --pull --push .
+      - name: build arm64 image
+        run: |
+          VERSION=$(git describe --tags --abbrev=0)
+          docker buildx build \
+            -t tensorchord/horust:${VERSION} -f envd.Dockerfile \
+            --platform linux/arm64 \
+            --build-arg ARCH=aarch64 \
             --pull --push .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           name: x86_64-unknown-linux-gnu
           path: amd64
-      - run: chmod 777 arm64/horust &&  chmod 777 amd64/horust
+      - run: chmod 755 arm64/horust &&  chmod 755 amd64/horust
       - name: build multi-arch 
         run: |
             VERSION=$(git describe --tags --abbrev=0)

--- a/envd.Dockerfile
+++ b/envd.Dockerfile
@@ -1,4 +1,6 @@
-FROM quay.io/pypa/manylinux2014_x86_64 as builder
+ARG ARCH
+
+FROM quay.io/pypa/manylinux2014_${ARCH} as builder
 
 USER root
 

--- a/envd.Dockerfile
+++ b/envd.Dockerfile
@@ -1,16 +1,6 @@
-ARG ARCH
-
-FROM quay.io/pypa/manylinux2014_${ARCH} as builder
-
-USER root
-
-RUN curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-
-COPY . /app/
-WORKDIR /app
-ENV PATH="${PATH}:/root/.cargo/bin"
-RUN cargo build --release
-
 FROM scratch
-COPY --from=builder /app/target/release/horust .
+
+ARG TARGETARCH
+COPY $TARGETARCH/horust .
+
 ENTRYPOINT [ "./horust" ]


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We got problems with the existing code：
1. now the workflow build and push images for each platform seperately, so the later uploaded image will overwrite the earlier uploaded image with the same tag.
2. depend on a large and outdated os base image `manylinux2014`.
3. slow


### Description
- use cross compile to accelerate compilation.
- use strategy.matrix to split target platforms to seperate jobs to compile parallelly.
- use buildx --platform to annotate image's platform on dockerhub which avoids overwritting same-tag images.


### How Has This Been Tested?
build envd image with new horust images on amd64/arm64 seperately.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
